### PR TITLE
chore(docs): expand instructions for first-time setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,31 +26,3 @@ BasedOnStyles = Krystal
 ```
 
 See [Vale's documentation on packages](https://vale.sh/docs/topics/packages/) for more information.
-
-### Setup whilst the Vale package is a private repository
-
-Before we make this Vale package public, it cannot be downloaded via `vale sync` with the above config. We'll use the GitHub CLI to simplify grabbing an auth token. You may generate a `PAT` and use that instead if you wish.
-
-> [!TIP]
-> Install the [GitHub CLI](https://cli.github.com/) and authenticate it first.
-
-```shell
-curl -L -H "Authorization: token $(gh auth token)" \
-     -o vale-package-0.1.0.zip \
-     https://github.com/krystal/vale-package/archive/refs/tags/v0.1.0.zip
-```
-
-Add `vale-package.zip` to `.gitignore`.
-
-Create `.vale.ini`.
-
-```ini
-StylesPath = vale-styles  # Location of styles directory
-MinAlertLevel = suggestion # Options: suggestion, warning, error
-Packages = vale-package-0.1.0.zip
-
-[*.md]  # Apply to markdown files
-BasedOnStyles = Krystal
-```
-
-Run `vale sync`.


### PR DESCRIPTION
Docs now show how to:

- add to existing vale config
- start from scratch (when/if the repo goes public)
- start from scratch (with the repo being private)