### PR TITLE
feat: add CF's meaningful link text check

### DIFF
--- a/styles/Krystal/MeaningfulLinkWords.yml
+++ b/styles/Krystal/MeaningfulLinkWords.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "**Warning**: Rewrite the link text for `%s` to be more descriptive. For more information, refer to [Descriptive link text](https://developers.cloudflare.com/style-guide/formatting/structure/links/#descriptive-link-text)."
+level: warning
+ignorecase: true
+scope: raw
+nonword: true
+tokens:
+  - \[here\]\(.*\)
+  - \[this page\]\(.*\)
+  - \[read more\]\(.*\)


### PR DESCRIPTION
Requires writers to link to `[some meaningful piece of documentation](https://example.org)` rather than telling users to click `[here](https://example.org)` to browse the same.