### PR TITLE
fix: by default include only .md files

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,7 +6,7 @@ Packages = alex, proselint, Readability, write-good
 
 Vocab = Krystal, Technical
 
-[*]
+[*.md]
 BasedOnStyles = alex, proselint, Readability, write-good, Vale
 
 write-good.E-Prime = NO


### PR DESCRIPTION
It's linting the contents of png files for instance. Drop a png into a project and run vale against the directory it's in. Then run `strings yourfile.png` :) 