### PR TITLE
chore: rename release zip to krystal-vale

### DIFF
--- a/.github/workflows/zip.yaml
+++ b/.github/workflows/zip.yaml
@@ -17,15 +17,15 @@ jobs:
 
     - name: Prepare files
       run: |
-        mkdir -p vale-package
-        cp -r styles vale-package/
-        cp .vale.ini vale-package/
+        mkdir -p krystal-vale
+        cp -r styles krystal-vale/
+        cp .vale.ini krystal-vale/
 
     - name: Zip files
-      run: zip -r vale-package.zip vale-package/
+      run: zip -r krystal-vale.zip krystal-vale/
 
     - name: Upload zip to release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: vale-package.zip
+        files: krystal-vale.zip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To get started, add the package to your configuration file (as shown below) and 
 
 ```ini
 StylesPath = styles # Use your normal style path here.
-Packages = https://github.com/krystal/vale-package/releases/latest/download/vale-package.zip
+Packages = https://github.com/krystal/vale-package/releases/latest/download/krystal-vale.zip
 ```
 
 ### Add Vale to a project
@@ -19,7 +19,7 @@ Create a `.vale.ini` at the project's root:
 ```ini
 StylesPath = vale-styles  # Location of styles directory
 MinAlertLevel = suggestion # Options: suggestion, warning, error
-Packages = https://github.com/krystal/vale-package/releases/latest/download/vale-package.zip
+Packages = https://github.com/krystal/vale-package/releases/latest/download/krystal-vale.zip
 ```
 
 See [Vale's documentation on packages](https://vale.sh/docs/topics/packages/) for more information.


### PR DESCRIPTION
Presently,

```shell
❯ vale sync
Syncing vale-package [1/1] ███████████████████████████████████████████ 100% | 0s
```

It'd be more descriptive within a project if it mentioned it was `krystal-vale` it was syncing.