### PR TITLE
feat: disable alex.ProfanityUnlikely

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -11,6 +11,7 @@ BasedOnStyles = alex, proselint, Readability, write-good, Vale
 
 write-good.E-Prime = NO
 write-good.Passive = NO
+alex.ProfanityUnlikely = NO
 
 [formats]
 mdx = md


### PR DESCRIPTION
It is not useful to us. Words like `failure` are valid more often than not.