### PR TITLE
feat: reduce the number of readability indexes

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,9 +9,12 @@ Vocab = Krystal, Technical
 [*.md]
 BasedOnStyles = alex, proselint, Readability, write-good, Vale
 
+alex.ProfanityUnlikely = NO
+Readability.AutomatedReadability = NO
+Readability.ColemanLiau = NO
+Readability.FleschReadingEase = NO
 write-good.E-Prime = NO
 write-good.Passive = NO
-alex.ProfanityUnlikely = NO
 
 [formats]
 mdx = md

--- a/.vale.ini
+++ b/.vale.ini
@@ -13,6 +13,7 @@ alex.ProfanityUnlikely = NO
 Readability.AutomatedReadability = NO
 Readability.ColemanLiau = NO
 Readability.FleschReadingEase = NO
+Readability.FleschKincaid = NO
 write-good.E-Prime = NO
 write-good.Passive = NO
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -12,8 +12,8 @@ BasedOnStyles = alex, proselint, Readability, write-good, Vale
 alex.ProfanityUnlikely = NO
 Readability.AutomatedReadability = NO
 Readability.ColemanLiau = NO
-Readability.FleschReadingEase = NO
 Readability.FleschKincaid = NO
+Readability.FleschReadingEase = NO
 write-good.E-Prime = NO
 write-good.Passive = NO
 


### PR DESCRIPTION
Go with:

 - Gunning Fog
 - SMOG
 - LIX

Some rudimentary research suggests these are better suited to British English. We don't need all of them enabled as they usually overlap.