### PR TITLE
fix: ignore code blocks

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -25,3 +25,6 @@ mdx = md
 BlockIgnores = (?s) *(<[^>]*>)
 BlockIgnores = (?s) *(import.*?\n)
 BlockIgnores = (?s) *(export.*?\))
+# Do not attempt to lint code, triple-backtick delimited or single backtick delimited
+BlockIgnores = ```[a-z]*[\s\S]*?\n```
+BlockIgnores = `[a-z]*[\s\S]*?\n`

--- a/.vale.ini
+++ b/.vale.ini
@@ -19,12 +19,3 @@ write-good.Passive = NO
 
 [formats]
 mdx = md
-
-[*.md]
-# These rules exist to allow JSX /HTML in markdown files.
-BlockIgnores = (?s) *(<[^>]*>)
-BlockIgnores = (?s) *(import.*?\n)
-BlockIgnores = (?s) *(export.*?\))
-# Do not attempt to lint code, triple-backtick delimited or single backtick delimited
-BlockIgnores = ```[a-z]*[\s\S]*?\n```
-BlockIgnores = `[a-z]*[\s\S]*?\n`


### PR DESCRIPTION
In some of the Katapult docs we have, for instance:

```
- `virtual_machine.network_interfaces[].ipv4_addresses[]...`
```

and some `xml` examples in a triple-backtick delimited block. At the moment these are currently being checked by Vale.

This is being caused by our set of BlockIgnores.