### PR TITLE
fix: allow plural acronym when used but not defined

### DIFF
--- a/styles/Krystal/Acronyms.yml
+++ b/styles/Krystal/Acronyms.yml
@@ -4,7 +4,7 @@ link:
 level: suggestion
 ignorecase: false
 # Ensures that the existence of 'first' implies the existence of 'second'.
-first: '\b([A-Z]{2,5}[s]?)\b'
+first: '\b([A-Z]{2,5}?)\b'
 second: '(?:\b[A-Z][a-z]+ )+\(([A-Z]{2,5}[s]?)\)'
 # ... with the exception of these:
 exceptions:


### PR DESCRIPTION
Fix allows for:

> Create a Virtual Machine (VM) as follows
> Do something with your VMs. Add something to your VM.

But doesn't work with plural when first defined:

> Create Virtual Machines (VMs)
> Do something with your VMs. Add something to your VM.

https://studio.vale.sh/s/211b37802ef4b2ad0901bc51d3082e93

Prior to this change:

![image](https://github.com/user-attachments/assets/5a3078f2-4f37-43ef-9b4b-ce4856ff77fc)
