### PR TITLE
fix: data center preferred style

### DIFF
--- a/styles/Krystal/SpellingSuggestions.yml
+++ b/styles/Krystal/SpellingSuggestions.yml
@@ -8,7 +8,7 @@ swap:
     nameserver[s]?:             name server(s)
     hyperthread(?:s|ed|ing)?:   hyper-thread(s)
     timeseries:                 time series
-    data center[s]?:            datacenter(s)
+    datacenter[s]?:             data center(s)
     ruleset[s]?:                rule set(s)
     multi-cloud:                multicloud
     cyberattack(?:|s|er):       cyber-attack(s)

--- a/styles/ignore/spelling-ignorelist.txt
+++ b/styles/ignore/spelling-ignorelist.txt
@@ -1,1 +1,3 @@
+center
+centers
 etc


### PR DESCRIPTION
- style in katapult website is space separated
- this causes center and centers to flag as non en GB