### PR TITLE
fix: allow ID or IDs plural

### DIFF
--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -124,7 +124,7 @@ HPA[s]?
 (HTTPS|https)
 [Hh]yperparameters?
 Icinga
-(?i)ID
+(?i)ID[s]?
 [Ii]dempotence
 [Ii]mpactful
 Infiniband


### PR DESCRIPTION
- `ID` is allowed
- allow `IDs` plural