### PR TITLE
feat: allow AI(s), ISO(s)

### DIFF
--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -1,9 +1,10 @@
 [Aa]ccessor[s]?
+[Aa]udiobook[s]?
 [Aa]llowlist[s]?
 [Aa]utocommit
 [Aa]utodeploy
 ACL[s]?
-[Aa]udiobook[s]?
+AI[s]?
 Algolia
 AMI[s]?
 Anchore
@@ -131,6 +132,7 @@ Infiniband
 inode[s]?
 IP[s]?
 IO
+ISO[s]?
 ISP[s]
 Istio
 iwantmyname


### PR DESCRIPTION
Whilst ISO can refer to standards or disk images, it'll be known in its context as to the intent. We would expect to see "ISO images" or "ISO 22301".