### PR TITLE
feat: simplify output for easier grokking

### DIFF
--- a/styles/Krystal/Gerunds.yml
+++ b/styles/Krystal/Gerunds.yml
@@ -1,13 +1,16 @@
 extends: script
 message: |
-  For a task-based heading, start with a [bare infinitive](https://en.wikipedia.org/wiki/Infinitive#English), also known as a plain form or [base form](https://en.wikipedia.org/wiki/English_verbs#Base_form) verb.
-  In English, the imperative mood also uses the base form verb, so it looks the same as the bare infinitive.
+  Don't use gerunds (-ing words) at the beginning of headings. Instead, use a bare infinitive or a noun phrase.
 
-  Task-based headings are frequently used in quickstarts, how-to documents, and tutorials.
-
-  For a conceptual or non-task-based heading, use a [noun phrase](https://en.wikipedia.org/wiki/Noun_phrase) that doesn't start with an -ing verb.
-
-  Noun-phrase headings are frequently used in concept documentation.
+# Further details:
+#  For a task-based heading, start with a [bare infinitive](https://en.wikipedia.org/wiki/Infinitive#English), also known as a plain form or [base form](https://en.wikipedia.org/wiki/English_verbs#Base_form) verb.
+#  In English, the imperative mood also uses the base form verb, so it looks the same as the bare infinitive.
+#
+#  Task-based headings are frequently used in quickstarts, how-to documents, and tutorials.
+#
+#  For a conceptual or non-task-based heading, use a [noun phrase](https://en.wikipedia.org/wiki/Noun_phrase) that doesn't start with an -ing verb.
+#
+#  Noun-phrase headings are frequently used in concept documentation.
 link: https://developers.google.com/style/headings#heading-and-title-text
 scope: heading
 script: |

--- a/styles/Krystal/Spelling.yml
+++ b/styles/Krystal/Spelling.yml
@@ -2,11 +2,14 @@ extends: spelling
 message: |
   Did you really mean '%s'?
 
-  For UI elements, use [bold formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
-  The spell checker doesn't check words with bold formatting.
+  You may need code/bold formatting.
 
-  For paths; configuration; user input; code; class, method, and variable names; statuscodes; and console output, use [code formatting](https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#bold).
-  The spell checker doesn't check words with code formatting.
+# Further details:
+#   For UI elements, use bold formatting.
+#
+#  For paths; configuration; user input; code; class, method, and variable names; statuscodes; and console output, use code formatting.
+#
+#  The spell checker doesn't check words with bold or code formatting.
 level: error
 dictionaries:
   - en_GB


### PR DESCRIPTION
Retain longer explanation as a comment for people searching the codebase for the error message.

Example output:

```
 1:3  warning  Don't use gerunds (-ing words)  Krystal.Gerunds 
               at the beginning of headings.                   
               Instead, use a bare infinitive                  
               or a noun phrase.            
```

```
 66:50    error       Did you really mean             Krystal.Spelling        
                      'wibble'? You may need                            
                      code/bold formatting.                               
```