### PR TITLE
fix: add healthcheck to vocab

### DIFF
--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -120,7 +120,7 @@ Hasura
 HDD[s]?
 Hetzner
 [Hh]ardcod(e|ed|ing)
-[Hh]ealthcheck
+[Hh]ealthcheck[s]?
 [Hh]ostname
 HPA[s]?
 (HTTP|http)

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -120,6 +120,7 @@ Hasura
 HDD[s]?
 Hetzner
 [Hh]ardcod(e|ed|ing)
+[Hh]ealthcheck
 [Hh]ostname
 HPA[s]?
 (HTTP|http)


### PR DESCRIPTION
Katapult uses healthcheck as 1 word.